### PR TITLE
Unify nav menu with reusable loader

### DIFF
--- a/assets/nav.js
+++ b/assets/nav.js
@@ -1,0 +1,15 @@
+function toggleSidebar() {
+  const sidebar = document.getElementById('sidebar');
+  const isOpen = sidebar.classList.toggle('open');
+  document.body.style.overflow = isOpen ? 'hidden' : '';
+}
+
+function loadNavigation() {
+  fetch('includes/nav.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('nav-container').innerHTML = html;
+    });
+}
+
+document.addEventListener('DOMContentLoaded', loadNavigation);

--- a/change_password.php
+++ b/change_password.php
@@ -17,7 +17,7 @@ if (!isset($_SESSION['user_id'])) {
 </head>
 <body class="sidebar-layout">
 
-<?php include 'includes/nav.php'; ?>
+<div id="nav-container"></div>
 
 <!-- Main Content -->
 <div class="main-content">
@@ -38,5 +38,6 @@ if (!isset($_SESSION['user_id'])) {
 
 
 
+<script src="assets/nav.js"></script>
 </body>
 </html>

--- a/dashboard.php
+++ b/dashboard.php
@@ -17,7 +17,7 @@ if (!isset($_SESSION['user_id'])) {
 </head>
 <body class="sidebar-layout">
 
-<?php include 'includes/nav.php'; ?>
+<div id="nav-container"></div>
 
 <!-- Main Content -->
 <div class="main-content">
@@ -25,6 +25,6 @@ if (!isset($_SESSION['user_id'])) {
   <p>This is your dashboard. From here, you can manage all operations and access ERP modules as they are built.</p>
 </div>
 
-
+<script src="assets/nav.js"></script>
 </body>
 </html>

--- a/includes/nav.html
+++ b/includes/nav.html
@@ -1,8 +1,3 @@
-<?php
-/**
- * Central navigation sidebar
- */
-?>
 <!-- Sidebar Toggle Button -->
 <button class="sidebar-toggle" onclick="toggleSidebar()">☰</button>
 
@@ -23,10 +18,4 @@
   </div>
 </div>
 
-<script>
-function toggleSidebar() {
-  const sidebar = document.getElementById('sidebar');
-  const isOpen = sidebar.classList.toggle('open');
-  document.body.style.overflow = isOpen ? 'hidden' : '';
-}
-</script>
+


### PR DESCRIPTION
## Summary
- create a single nav markup file and load it dynamically
- add JS helper to fetch nav on each page
- remove per-page nav markup

## Testing
- `php -l dashboard.php`
- `php -l change_password.php`
- `php -l index.php`
- `php -l login.php`
- `php -l logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68863059296c8332bb090953c6ff42bb